### PR TITLE
[Phase 1] Docker + Docker Compose setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,53 +1,73 @@
 # NetworkCrawler — Multi-stage Dockerfile
 #
-# Stage 1: build the React frontend
-# Stage 2: production image serving both FastAPI + static frontend assets
+# Stage 1 — frontend build (Node): compiles the React/Vite app to static assets.
+# Stage 2 — production image (Python slim): runs FastAPI and serves frontend assets.
 #
-# Security: container runs as non-root user (uid 1000)
-# Network:  requires host network mode + --cap-add=NET_RAW for arp-scan/nmap
+# Security notes:
+#   • Container runs as a non-root user (uid/gid 1000).
+#   • Raw socket access for nmap/arp-scan is granted via --cap-add=NET_RAW at
+#     runtime (see docker-compose.yml). Do NOT run the container as root.
+#   • Host network mode is required so arp-scan can reach the LAN broadcast domain.
 
-# ── Stage 1: frontend build ────────────────────────────────────────────────
+# ── Stage 1: build the React frontend ────────────────────────────────────────
 FROM node:20-alpine AS frontend-build
 
-WORKDIR /build/frontend
+WORKDIR /build
 
 COPY frontend/package.json frontend/package-lock.json* ./
+# ci install — deterministic, skips devDep postinstall scripts on prod
 RUN npm ci --prefer-offline
 
 COPY frontend/ ./
 RUN npm run build
-# Output: /build/frontend/dist
+# Outputs compiled assets to /build/dist
 
-# ── Stage 2: production image ─────────────────────────────────────────────
+
+# ── Stage 2: production runtime ──────────────────────────────────────────────
 FROM python:3.11-slim AS production
 
-# Install system dependencies (nmap, arp-scan)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    nmap \
-    arp-scan \
+LABEL org.opencontainers.image.title="NetworkCrawler" \
+      org.opencontainers.image.description="LAN security posture scanner for home lab operators" \
+      org.opencontainers.image.source="https://github.com/reloadfast/NetworkCrawler"
+
+# Install system-level scanning tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        nmap \
+        arp-scan \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r crawler && useradd -r -g crawler -u 1000 crawler
+# Create a dedicated non-root user
+RUN groupadd --gid 1000 crawler \
+    && useradd --uid 1000 --gid crawler --no-create-home --shell /usr/sbin/nologin crawler
 
 WORKDIR /app
 
-# Install Python dependencies
+# Install Python dependencies before copying source (layer-cache friendly)
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy backend source
+# Copy application source
 COPY backend/ ./backend/
 
-# Copy built frontend static assets
-COPY --from=frontend-build /build/frontend/dist ./frontend/dist
+# Copy compiled frontend assets — served as static files by FastAPI
+COPY --from=frontend-build /build/dist ./frontend/dist
 
-# Set ownership
-RUN chown -R crawler:crawler /app
+# Persist the SQLite database in a dedicated data directory
+RUN mkdir -p /app/data && chown -R crawler:crawler /app
 
+# Drop to non-root
 USER crawler
 
+# FastAPI listens on 8000; the host-network container is accessible on <host-ip>:8000
 EXPOSE 8000
 
-# Note: nmap/arp-scan need NET_RAW capability — add via docker-compose or --cap-add=NET_RAW
-CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Healthcheck — lightweight; used by Docker and Compose
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+CMD ["uvicorn", "backend.app.main:app", \
+     "--host", "0.0.0.0", \
+     "--port", "8000", \
+     "--proxy-headers", \
+     "--forwarded-allow-ips", "*"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,9 +2,15 @@ version: "3.9"
 
 # NetworkCrawler — Docker Compose stack
 #
-# Requires host network mode so arp-scan can reach the LAN broadcast domain.
-# NET_RAW capability is required for arp-scan and nmap raw socket access.
-# Container runs as uid 1000 (non-root) — defined in the Dockerfile.
+# ┌─ IMPORTANT NOTES ──────────────────────────────────────────────────────────┐
+# │  network_mode: host                                                         │
+# │    Required so arp-scan can reach the LAN broadcast domain. The app is      │
+# │    accessible at http://<host-ip>:8000 — no port mapping needed.            │
+# │                                                                              │
+# │  cap_add: [NET_RAW]                                                          │
+# │    Grants raw socket access for arp-scan and nmap without running as root.   │
+# │    The container still runs as uid 1000 (non-root, set in Dockerfile).       │
+# └─────────────────────────────────────────────────────────────────────────────┘
 
 services:
   networkcrawler:
@@ -12,32 +18,38 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     container_name: networkcrawler
+    image: networkcrawler:latest
 
-    # Host network mode: required for ARP visibility across the LAN
+    # Host networking — required for ARP visibility across the LAN subnet
     network_mode: host
 
-    # Raw socket access for nmap and arp-scan
+    # Raw-socket capability — required for arp-scan and nmap; runs as uid 1000
     cap_add:
       - NET_RAW
 
-    # Never run as root
-    # (user is set in Dockerfile; reinforced here)
-    user: "1000:1000"
-
+    # All env vars wired from .env (copy .env.example → .env before first run)
     environment:
       NETWORK_INTERFACE: ${NETWORK_INTERFACE:-eth0}
       SCAN_SUBNET: ${SCAN_SUBNET:-192.168.1.0/24}
       SCAN_INTERVAL_SECONDS: ${SCAN_INTERVAL_SECONDS:-3600}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      # Database path inside the container; maps to the volume below
+      DATABASE_URL: sqlite:////app/data/networkcrawler.db
 
     volumes:
-      # Persist the SQLite database across restarts
+      # Persist the SQLite database across container restarts and upgrades
       - networkcrawler_data:/app/data
 
     restart: unless-stopped
 
-    # Port is accessible only within the LAN via host networking (no explicit port mapping needed)
-    # Access the UI at http://<host-ip>:8000
+    # Healthcheck mirrors the Dockerfile HEALTHCHECK (Compose honours it too)
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
 
 volumes:
   networkcrawler_data:


### PR DESCRIPTION
## Summary

- **Multi-stage `Dockerfile`**: Node 20 Alpine builds the React frontend; Python 3.11-slim production stage installs nmap, arp-scan, and the FastAPI app, then copies compiled frontend assets.
- **Non-root user**: `crawler` (uid/gid 1000) created and set as `USER`; `/app` ownership transferred before the `USER` instruction.
- **`docker-compose.yml`**: `network_mode: host` for ARP/LAN visibility; `cap_add: [NET_RAW]` for raw socket access; all four env vars wired from `.env`; named volume for SQLite persistence; healthcheck; `restart: unless-stopped`.
- **`.env.example`**: documents all four required env vars with safe placeholder values.
- **Unraid CA template** (`unraid/NetworkCrawler.xml`, gitignored): host network, `NET_RAW`, all env vars as `<Config>` elements, `/app/data` volume, `<Privileged>false</Privileged>`.

## Validation
All acceptance-criteria checks verified programmatically (no Docker daemon needed):
- ✓ Multi-stage build, non-root user, nmap/arp-scan installed, HEALTHCHECK, EXPOSE 8000
- ✓ Compose: host network, NET_RAW, all four env vars, volume, healthcheck, restart policy
- ✓ Unraid template: host network, NET_RAW, all four vars, /app/data volume, Privileged=false
- ✓ `unraid/` not tracked by git (correctly gitignored)

> **Note:** A live `docker build` requires the `backend/` and `frontend/` trees from PR #17 to be on `main` first. Merge order: #17 → #18.

Closes #2