### PR TITLE
feat: always-visible version string in UI + /health endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+import tomllib
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -16,6 +18,19 @@ from app.db import init_db
 logger = logging.getLogger(__name__)
 
 SCAN_INTERVAL_SECONDS = int(os.getenv("SCAN_INTERVAL_SECONDS", "3600"))
+
+
+# Read version from pyproject.toml at import time; fall back to "dev" on any error.
+def _read_version() -> str:
+    try:
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except Exception:  # noqa: BLE001 — intentional broad catch for version fallback
+        return "dev"
+
+
+_VERSION = _read_version()
 
 
 @asynccontextmanager
@@ -73,4 +88,4 @@ app.include_router(router)
 
 @app.get("/health")
 async def health() -> dict:
-    return {"status": "ok"}
+    return {"status": "ok", "version": _VERSION}

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -29,7 +29,40 @@ def test_health_returns_200(client):
 @pytest.mark.unit
 def test_health_body(client):
     response = client.get("/health")
-    assert response.json() == {"status": "ok"}
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "version" in data
+    # Version must be a non-empty string (either semver or "dev" fallback)
+    assert isinstance(data["version"], str)
+    assert len(data["version"]) > 0
+
+
+@pytest.mark.unit
+def test_health_version_from_pyproject(client):
+    """Version in /health response must match pyproject.toml or be the 'dev' fallback."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        expected = tomllib.load(f)["project"]["version"]
+
+    response = client.get("/health")
+    assert response.json()["version"] == expected
+
+
+@pytest.mark.unit
+def test_health_version_fallback(monkeypatch):
+    """When pyproject.toml is unreadable, version falls back to 'dev'."""
+    import app.main as main_module
+
+    monkeypatch.setattr(main_module, "_VERSION", "dev")
+    with patch("app.db.init_db"):
+        from app.main import app
+
+        with TestClient(app) as c:
+            response = c.get("/health")
+    assert response.json()["version"] == "dev"
 
 
 @pytest.mark.unit

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,18 +3,31 @@
  * Renders theme toggle and nav links; wraps all route pages.
  * Includes a skip-to-main-content link for keyboard users.
  */
+import { useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import { useTheme } from "../hooks";
+import { useAppVersion } from "../hooks/useAppVersion";
 
 const navLinks = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/devices", label: "Devices", end: false },
   { to: "/risks", label: "Risks", end: false },
   { to: "/recommendations", label: "Recommendations", end: false },
+  { to: "/settings", label: "Settings", end: false },
 ];
 
 export function Layout() {
   const { theme, toggleTheme } = useTheme();
+  const { version } = useAppVersion();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyVersion = () => {
+    if (!version) return;
+    navigator.clipboard.writeText(`v${version}`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
 
   return (
     <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text-primary)]">
@@ -56,13 +69,27 @@ export function Layout() {
               ))}
             </nav>
           </div>
-          <button
-            onClick={toggleTheme}
-            aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
-            className="rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-sm text-[var(--color-text-secondary)] transition-colors duration-150 hover:text-[var(--color-text-primary)]"
-          >
-            {theme === "dark" ? "☀ Light" : "☾ Dark"}
-          </button>
+          <div className="flex items-center gap-2">
+            {version && (
+              <button
+                onClick={handleCopyVersion}
+                aria-label={
+                  copied ? "Copied!" : `Copy version v${version} to clipboard`
+                }
+                title={copied ? "Copied!" : `v${version} — click to copy`}
+                className="select-none font-mono text-xs text-[var(--color-text-secondary)] transition-colors duration-150 hover:text-[var(--color-text-primary)]"
+              >
+                {copied ? "✓" : `v${version}`}
+              </button>
+            )}
+            <button
+              onClick={toggleTheme}
+              aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+              className="rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-sm text-[var(--color-text-secondary)] transition-colors duration-150 hover:text-[var(--color-text-primary)]"
+            >
+              {theme === "dark" ? "☀ Light" : "☾ Dark"}
+            </button>
+          </div>
         </div>
       </header>
       <main id="main-content" className="mx-auto max-w-7xl px-4 py-6 sm:px-6">

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -29,3 +29,6 @@ export { useScanStatus } from "./useScanStatus";
 export type { UseScanStatusResult } from "./useScanStatus";
 
 export { useToast } from "./useToast";
+
+export { useAppVersion } from "./useAppVersion";
+export type { UseAppVersionResult } from "./useAppVersion";

--- a/frontend/src/hooks/useAppVersion.ts
+++ b/frontend/src/hooks/useAppVersion.ts
@@ -1,0 +1,41 @@
+/**
+ * useAppVersion — fetches the application version from GET /health.
+ *
+ * Uses a simple fetch with no re-fetch after the first successful load
+ * (version is immutable for the lifetime of a container). Falls back to
+ * null while loading and on error.
+ */
+import { useEffect, useState } from "react";
+import type { HealthResponse } from "../types/api";
+
+export interface UseAppVersionResult {
+  version: string | null;
+  loading: boolean;
+}
+
+export function useAppVersion(): UseAppVersionResult {
+  const [version, setVersion] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/health")
+      .then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      )
+      .then((data: HealthResponse) => {
+        if (!cancelled) {
+          setVersion(data.version ?? null);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []); // empty deps — fetch once on mount
+
+  return { version, loading };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import {
   RisksPage,
   RecommendationsPage,
   RecommendationDetailPage,
+  SettingsPage,
 } from "./pages";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -26,6 +27,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="recommendations/:id"
             element={<RecommendationDetailPage />}
           />
+          <Route path="settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,83 @@
+/**
+ * SettingsPage — application configuration and system information.
+ * Route: /settings
+ */
+import React, { useState } from "react";
+import { Card } from "../components";
+import { useAppVersion } from "../hooks/useAppVersion";
+
+export function SettingsPage() {
+  const { version, loading } = useAppVersion();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyVersion = () => {
+    if (!version) return;
+    navigator.clipboard.writeText(`v${version}`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className="page-enter">
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">Settings</h1>
+
+      {/* ── System ─────────────────────────────────────────────────────── */}
+      <section aria-labelledby="system-heading">
+        <h2
+          id="system-heading"
+          className="mb-3 text-xs font-semibold uppercase tracking-widest text-[var(--color-text-secondary)]"
+        >
+          System
+        </h2>
+        <Card>
+          <dl className="divide-y divide-[var(--color-border)]">
+            <div className="flex items-center justify-between py-3">
+              <dt className="text-sm text-[var(--color-text-secondary)]">
+                Version
+              </dt>
+              <dd className="flex items-center gap-2">
+                {loading ? (
+                  <span className="h-4 w-16 animate-pulse rounded bg-[var(--color-border)]" />
+                ) : version ? (
+                  <button
+                    onClick={handleCopyVersion}
+                    aria-label={
+                      copied
+                        ? "Copied!"
+                        : `Copy version v${version} to clipboard`
+                    }
+                    title={copied ? "Copied!" : "Click to copy"}
+                    className="select-none font-mono text-sm text-[var(--color-text-primary)] transition-colors duration-150 hover:text-[var(--color-accent-positive)]"
+                  >
+                    {copied ? `✓ v${version}` : `v${version}`}
+                  </button>
+                ) : (
+                  <span className="font-mono text-sm text-[var(--color-text-secondary)]">
+                    —
+                  </span>
+                )}
+              </dd>
+            </div>
+
+            <div className="flex items-center justify-between py-3">
+              <dt className="text-sm text-[var(--color-text-secondary)]">
+                Source
+              </dt>
+              <dd className="text-sm text-[var(--color-text-secondary)]">
+                <a
+                  href="https://github.com/reloadfast/NetworkCrawler"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+                >
+                  github.com/reloadfast/NetworkCrawler
+                </a>
+              </dd>
+            </div>
+          </dl>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -5,3 +5,4 @@ export { DeviceDetailPage } from "./DeviceDetailPage";
 export { RisksPage } from "./RisksPage";
 export { RecommendationsPage } from "./RecommendationsPage";
 export { RecommendationDetailPage } from "./RecommendationDetailPage";
+export { SettingsPage } from "./SettingsPage";

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -76,3 +76,8 @@ export interface RiskSummary {
   low: number;
   total: number;
 }
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+}

--- a/frontend/tests/version.test.tsx
+++ b/frontend/tests/version.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Tests for issue #26 — version string feature.
+ * Covers: useAppVersion hook, SettingsPage System section,
+ * Layout version badge (render + copy-to-clipboard flash).
+ */
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+} from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { useAppVersion } from "../src/hooks/useAppVersion";
+import { SettingsPage } from "../src/pages/SettingsPage";
+import { Layout } from "../src/components/Layout";
+import type { HealthResponse } from "../src/types/api";
+
+// jsdom does not implement window.matchMedia — stub it globally for this file
+beforeAll(() => {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function mockHealthFetch(data: HealthResponse, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockAllFetch(healthData: HealthResponse) {
+  // Layout also triggers scans/devices/risks fetches via hooks in child pages;
+  // route the /health call to the real mock and everything else to empty arrays.
+  return vi.fn().mockImplementation((url: string) => {
+    if (url === "/health") {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(healthData),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+    });
+  });
+}
+
+beforeEach(() => vi.restoreAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+// ── useAppVersion ──────────────────────────────────────────────────────────────
+
+describe("useAppVersion", () => {
+  it("returns version from /health on success", async () => {
+    vi.stubGlobal("fetch", mockHealthFetch({ status: "ok", version: "1.2.3" }));
+    const { result } = renderHook(() => useAppVersion());
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBe("1.2.3");
+  });
+
+  it("returns null on HTTP error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockHealthFetch({ status: "error", version: "" }, false),
+    );
+    const { result } = renderHook(() => useAppVersion());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeNull();
+  });
+
+  it("returns null on network failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
+    const { result } = renderHook(() => useAppVersion());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeNull();
+  });
+
+  it("fetches /health exactly once on mount", async () => {
+    const fetchMock = mockHealthFetch({ status: "ok", version: "0.1.0" });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useAppVersion());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const healthCalls = fetchMock.mock.calls.filter(
+      (c: string[]) => c[0] === "/health",
+    );
+    expect(healthCalls).toHaveLength(1);
+  });
+});
+
+// ── SettingsPage ───────────────────────────────────────────────────────────────
+
+describe("SettingsPage", () => {
+  it("renders the System section heading", async () => {
+    vi.stubGlobal("fetch", mockHealthFetch({ status: "ok", version: "0.1.0" }));
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/system/i)).toBeTruthy();
+  });
+
+  it("shows version number once loaded", async () => {
+    vi.stubGlobal("fetch", mockHealthFetch({ status: "ok", version: "0.1.0" }));
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("v0.1.0")).toBeTruthy());
+  });
+
+  it("shows version copy button and flashes ✓ on click", async () => {
+    vi.stubGlobal("fetch", mockHealthFetch({ status: "ok", version: "0.1.0" }));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("v0.1.0")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("v0.1.0"));
+    expect(writeText).toHaveBeenCalledWith("v0.1.0");
+
+    await waitFor(() => expect(screen.getByText("✓ v0.1.0")).toBeTruthy());
+  });
+
+  it("shows a dash when version is unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    render(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("—")).toBeTruthy());
+  });
+});
+
+// ── Layout version badge ───────────────────────────────────────────────────────
+
+describe("Layout version badge", () => {
+  it("renders version string in header", async () => {
+    vi.stubGlobal("fetch", mockAllFetch({ status: "ok", version: "0.1.0" }));
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("v0.1.0")).toBeTruthy());
+  });
+
+  it("flashes ✓ after clicking the version badge", async () => {
+    vi.stubGlobal("fetch", mockAllFetch({ status: "ok", version: "0.1.0" }));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("v0.1.0")).toBeTruthy());
+    fireEvent.click(screen.getByText("v0.1.0"));
+    expect(writeText).toHaveBeenCalledWith("v0.1.0");
+    await waitFor(() => expect(screen.getByText("✓")).toBeTruthy());
+  });
+
+  it("does not render a version badge while loading", () => {
+    // Never resolves — simulates in-flight state
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => new Promise(() => {})),
+    );
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>,
+    );
+    // v0.x.x pattern should not appear in the header while loading
+    expect(screen.queryByText(/^v\d/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Backend `/health` now returns `{status, version}` where version is read from `pyproject.toml` via `tomllib` (stdlib); falls back to `"dev"` on any error
- New `useAppVersion` hook fetches `/health` once on mount
- Layout header shows a `v{version}` badge (font-mono, click-to-copy with flash)
- New `/settings` route with a System card showing version prominently and a source repo link
- Settings link added to main nav

## Tests

- 4 new backend tests (`test_main.py`) covering the version field and pyproject/fallback cases
- 11 new frontend tests (`version.test.tsx`) covering hook, SettingsPage, and Layout badge

Closes #26