### PR TITLE
fix: surface arp-scan errors instead of silently returning no hosts

### DIFF
--- a/backend/app/scanner/arp_scan.py
+++ b/backend/app/scanner/arp_scan.py
@@ -52,7 +52,16 @@ def run_arp_scan(
         timeout=60,
     )
 
-    if result.returncode not in (0, 1):  # arp-scan returns 1 when no hosts found
+    if result.stderr.strip():
+        logger.warning("arp-scan stderr: %s", result.stderr.strip())
+    logger.debug("arp-scan stdout: %s", result.stdout.strip() or "(empty)")
+
+    # Exit code 1 with stderr output is a real error (e.g. permission denied,
+    # unknown interface). Exit code 1 with no stderr means no hosts found.
+    if result.returncode == 1 and result.stderr.strip():
+        raise RuntimeError(f"arp-scan failed (exit 1): {result.stderr.strip()}")
+
+    if result.returncode not in (0, 1):
         raise RuntimeError(f"arp-scan failed (exit {result.returncode}): {result.stderr.strip()}")
 
     return parse_arp_output(result.stdout)

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -115,11 +115,23 @@ class TestRunArpScan:
 
     @pytest.mark.unit
     def test_returns_empty_list_when_no_hosts_found(self):
-        """arp-scan exits 1 when no hosts are found — must not raise."""
+        """arp-scan exits 1 with empty stderr when no hosts found — must not raise."""
         mock_result = MagicMock(returncode=1, stdout="", stderr="")
         with patch("app.scanner.arp_scan.subprocess.run", return_value=mock_result):
             hosts = run_arp_scan(interface="eth0", subnet="192.168.1.0/24")
         assert hosts == []
+
+    @pytest.mark.unit
+    def test_raises_on_exit1_with_stderr(self):
+        """Exit code 1 with stderr content is a real error (e.g. permission denied) — must raise."""
+        mock_result = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="ERROR: socket(PF_PACKET, SOCK_RAW, 8): Operation not permitted",
+        )
+        with patch("app.scanner.arp_scan.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="arp-scan failed"):
+                run_arp_scan()
 
     @pytest.mark.unit
     def test_raises_on_nonzero_exit(self):


### PR DESCRIPTION
## Problem

arp-scan completes in ~2ms and finds 0 hosts. The actual error from arp-scan (e.g. `Operation not permitted` from missing `NET_RAW` capability, or unknown interface) was written to stderr but never logged or raised — silently treated as an empty scan result.

## Root Cause

arp-scan uses exit code `1` for two distinct situations:

| Situation | stderr | Previous behaviour | Correct behaviour |
|---|---|---|---|
| No hosts found (successful scan) | empty | return `[]` ✅ | return `[]` ✅ |
| Real error (permission, bad interface) | non-empty | return `[]` ❌ | raise `RuntimeError` ✅ |

Previously **both cases returned `[]`**, hiding the actual error entirely.

## Changes

- **Always log `stderr` at `WARNING`** when arp-scan writes to it (regardless of exit code)
- **Always log `stdout` at `DEBUG`** for full scan output visibility  
- **Raise `RuntimeError`** when exit code is `1` AND stderr is non-empty — this is a real error

## After this fix

The scan error will appear in logs as:
```
WARNING app.scanner.arp_scan: arp-scan stderr: ERROR: socket(PF_PACKET, SOCK_RAW, 8): Operation not permitted
```

This makes the actual problem (missing `NET_RAW` cap, wrong interface name, etc.) immediately visible.

## Test added

`test_raises_on_exit1_with_stderr` — verifies permission-denied / interface errors are raised rather than swallowed.