### PR TITLE
fix: grant cap_net_raw to scanner binaries for non-root execution

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,12 +33,19 @@ LABEL org.opencontainers.image.title="NetworkCrawler" \
       org.opencontainers.image.vendor="talesofthemoon" \
       org.opencontainers.image.licenses="MIT"
 
-# Install system-level scanning tools
+# Install system-level scanning tools + libcap2-bin for setcap
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         nmap \
         arp-scan \
+        libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
+
+# Grant cap_net_raw to the scanner binaries so they can open raw sockets when
+# running as non-root uid 1000.  --cap-add=NET_RAW at runtime puts NET_RAW in
+# the bounding set; setcap +ep promotes it to the effective set on exec.
+RUN setcap cap_net_raw+ep /usr/sbin/arp-scan \
+    && setcap cap_net_raw+ep "$(which nmap)"
 
 # Create a dedicated non-root user
 RUN groupadd --gid 1000 crawler \


### PR DESCRIPTION
## Problem

arp-scan and nmap fail with `Operation not permitted` even when the container is started with `--cap-add=NET_RAW`.

## Root Cause

Linux capability model has three relevant sets:
- **Bounding set** — `--cap-add=NET_RAW` adds it here
- **Permitted set** — inherited from bounding for root; for non-root, requires ambient or file caps
- **Effective set** — what the kernel actually checks on each syscall

When a **non-root** process (uid 1000) executes a binary, the effective set starts empty. The bounding set alone is not enough — the capability must also be on the **binary file** via `setcap`, or in the ambient set.

## Fix

Install `libcap2-bin` and apply `setcap cap_net_raw+ep` to both scanner binaries in the Dockerfile:

```
setcap cap_net_raw+ep /usr/sbin/arp-scan
setcap cap_net_raw+ep $(which nmap)
```

`+ep` = effective + permitted bits on the file. When uid 1000 executes the binary, the kernel promotes NET_RAW to the effective set. `--cap-add=NET_RAW` must still be present at runtime — file capabilities cannot exceed the bounding set.