### PR TITLE
fix: remove -O from nmap; OS detection requires root

### DIFF
--- a/backend/app/scanner/nmap_scan.py
+++ b/backend/app/scanner/nmap_scan.py
@@ -64,7 +64,9 @@ def run_nmap_scan(
         cmd = [
             "nmap",
             "-sV",  # service/version detection
-            "-O",  # OS detection (best-effort)
+            # -O (OS detection) intentionally omitted: nmap hard-codes geteuid()==0
+            # for OS fingerprinting regardless of file capabilities, so it always
+            # quits when running as non-root uid 1000.  os_guess will be empty.
             "--top-ports",
             "1000",
             "-e",

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -271,6 +271,24 @@ class TestRunNmapScan:
     """run_nmap_scan() mocks subprocess.run; XML writing verified via fixture."""
 
     @pytest.mark.unit
+    def test_does_not_use_os_detection_flag(self):
+        """-O must not appear in the nmap command: it hard-codes geteuid()==0 and
+        always quits when running as non-root uid 1000, regardless of file caps."""
+        fixture_xml = _fixture("nmap_two_hosts.xml")
+
+        def fake_run(cmd, **kwargs):
+            idx = cmd.index("-oX")
+            Path(cmd[idx + 1]).write_text(fixture_xml)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.scanner.nmap_scan.subprocess.run", side_effect=fake_run) as mock_run:
+            run_nmap_scan(hosts=["192.168.1.1"], interface="eth0")
+
+        cmd = mock_run.call_args[0][0]
+        assert "-O" not in cmd
+        assert "-sV" in cmd
+
+    @pytest.mark.unit
     def test_returns_empty_list_for_empty_hosts(self):
         assert run_nmap_scan(hosts=[]) == []
 


### PR DESCRIPTION
## Problem
ARP scan finds hosts correctly, but nmap immediately quits:
```
TCP/IP fingerprinting (for OS scan) requires root privileges. QUITTING!
```
This aborts the entire nmap run — no port or service data is collected.

## Root Cause
nmap's OS detection (`-O`) contains a hard-coded `geteuid() == 0` check. File capabilities (`setcap cap_net_raw+ep`) do not affect `geteuid()` — it always returns non-zero for uid 1000. No capability-based workaround exists.

## Fix
Remove `-O` from the nmap command. Per `system_config.md`, OS detection was already documented as "best-effort". `os_guess` will be an empty string; all port and service/version data is unaffected.

## Test
`test_does_not_use_os_detection_flag` — asserts `-O` is absent and `-sV` is present in the built command.