### PR TITLE
fix: XML crash, CIDR validation, stale ports, severity constants, error toast (#63 #64 #66 #69 #70)

### DIFF
--- a/backend/app/scan_runner.py
+++ b/backend/app/scan_runner.py
@@ -107,6 +107,10 @@ def run_scan_and_persist(triggered_by: str = "scheduler") -> int:
 
 def _persist_result(db: Session, result: ScanResult) -> None:
     """Upsert all devices and ports from a ScanResult into the database."""
+    from sqlalchemy import select
+
+    from app.models.device import Port
+
     # Full nmap results
     for nh in result.hosts:
         device = upsert_device(
@@ -117,6 +121,8 @@ def _persist_result(db: Session, result: ScanResult) -> None:
             os_guess=nh.os_guess or None,
         )
         db.flush()
+
+        current_ports = {(p.port_number, p.protocol) for p in nh.ports}
         for port in nh.ports:
             upsert_port(
                 db,
@@ -126,6 +132,12 @@ def _persist_result(db: Session, result: ScanResult) -> None:
                 service_name=port.service_name or None,
                 version_banner=port.version_banner or None,
             )
+
+        # Remove ports no longer seen in this scan
+        existing_ports = db.execute(select(Port).where(Port.device_id == device.id)).scalars().all()
+        for existing in existing_ports:
+            if (existing.port_number, existing.protocol) not in current_ports:
+                db.delete(existing)
 
     # ARP-only hosts (no nmap data)
     for ah in result.arp_only:

--- a/backend/app/scanner/__init__.py
+++ b/backend/app/scanner/__init__.py
@@ -7,6 +7,7 @@ scheduler and the manual-trigger API endpoint.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 from dataclasses import dataclass, field
@@ -47,6 +48,11 @@ def orchestrate_scan(
     """
     iface = interface or os.environ.get("NETWORK_INTERFACE", "eth0")
     net = subnet or os.environ.get("SCAN_SUBNET", "192.168.1.0/24")
+
+    try:
+        ipaddress.ip_network(net, strict=False)
+    except ValueError as exc:
+        raise ValueError(f"Invalid SCAN_SUBNET '{net}': {exc}") from exc
 
     logger.info("Starting ARP scan on %s / %s", iface, net)
     arp_hosts = run_arp_scan(interface=iface, subnet=net)

--- a/backend/app/scanner/nmap_scan.py
+++ b/backend/app/scanner/nmap_scan.py
@@ -101,8 +101,14 @@ def parse_nmap_xml(xml_text: str) -> list[NmapHost]:
 
     Only 'up' hosts with at least one port entry are included; filtered
     ports (state != 'open') are silently skipped.
+
+    Raises RuntimeError on malformed/truncated XML so the caller's partial-scan
+    handler can continue with ARP-only results rather than crashing.
     """
-    root = ET.fromstring(xml_text)  # noqa: S314 — input is local nmap output, not user data
+    try:
+        root = ET.fromstring(xml_text)  # noqa: S314 — input is local nmap output, not user data
+    except ET.ParseError as exc:
+        raise RuntimeError(f"nmap XML is malformed or truncated: {exc}") from exc
     results: list[NmapHost] = []
 
     for host_el in root.findall("host"):

--- a/backend/tests/test_scan_runner.py
+++ b/backend/tests/test_scan_runner.py
@@ -265,3 +265,59 @@ def test_partial_scan_persists_arp_devices_when_nmap_fails(in_memory_session_fac
     devices = db.query(Device).filter(Device.ip_address == "192.168.1.50").all()
     assert len(devices) == 1
     db.close()
+
+
+@pytest.mark.unit
+def test_stale_ports_removed_on_rescan(in_memory_session_factory, monkeypatch):
+    """Ports from a previous scan that are absent in the current scan must be deleted."""
+    from app.models.device import Port
+    from app.scan_runner import run_scan_and_persist
+    from app.scanner import ScanResult
+    from app.scanner.nmap_scan import NmapHost, PortInfo
+
+    monkeypatch.setattr("app.scan_runner.SessionLocal", in_memory_session_factory)
+
+    # First scan: device has ports 22 and 80
+    first_result = ScanResult(
+        hosts=[
+            NmapHost(
+                ip="192.168.1.10",
+                hostname="myhost",
+                ports=[
+                    PortInfo(port_number=22, protocol="tcp", state="open", service_name="ssh"),
+                    PortInfo(port_number=80, protocol="tcp", state="open", service_name="http"),
+                ],
+            )
+        ],
+        arp_only=[],
+    )
+    with patch("app.scan_runner.orchestrate_scan", return_value=first_result):
+        run_scan_and_persist("manual")
+
+    db = in_memory_session_factory()
+    ports_after_first = db.query(Port).filter(Port.port_number.in_([22, 80])).all()
+    assert len(ports_after_first) == 2
+    db.close()
+
+    # Second scan: device now only has port 22 (80 closed)
+    second_result = ScanResult(
+        hosts=[
+            NmapHost(
+                ip="192.168.1.10",
+                hostname="myhost",
+                ports=[
+                    PortInfo(port_number=22, protocol="tcp", state="open", service_name="ssh"),
+                ],
+            )
+        ],
+        arp_only=[],
+    )
+    with patch("app.scan_runner.orchestrate_scan", return_value=second_result):
+        run_scan_and_persist("manual")
+
+    db2 = in_memory_session_factory()
+    remaining = db2.query(Port).all()
+    port_numbers = [p.port_number for p in remaining]
+    assert 22 in port_numbers
+    assert 80 not in port_numbers, "Stale port 80 should have been removed"
+    db2.close()

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -488,3 +488,41 @@ class TestOrchestrateScan:
 
         cmd = mock_run.call_args[0][0]
         assert cmd[cmd.index("--host-timeout") + 1] == "60s"
+
+
+@pytest.mark.unit
+def test_parse_nmap_xml_raises_runtime_error_on_malformed_xml():
+    """Truncated or malformed nmap XML must raise RuntimeError, not ParseError."""
+    from app.scanner.nmap_scan import parse_nmap_xml
+
+    with pytest.raises(RuntimeError, match="malformed or truncated"):
+        parse_nmap_xml("<nmaprun><host><statu")  # truncated mid-tag
+
+
+@pytest.mark.unit
+def test_parse_nmap_xml_raises_runtime_error_on_empty_string():
+    from app.scanner.nmap_scan import parse_nmap_xml
+
+    with pytest.raises(RuntimeError):
+        parse_nmap_xml("")
+
+
+@pytest.mark.unit
+def test_orchestrate_scan_raises_on_invalid_cidr(monkeypatch):
+    """Invalid SCAN_SUBNET must raise ValueError before any scan tools are called."""
+    from app.scanner import orchestrate_scan
+
+    monkeypatch.setenv("SCAN_SUBNET", "not-a-cidr")
+    with pytest.raises(ValueError, match="Invalid SCAN_SUBNET"):
+        orchestrate_scan()
+
+
+@pytest.mark.unit
+def test_orchestrate_scan_accepts_valid_cidr(monkeypatch):
+    """Valid CIDR must not raise — passes through to arp-scan."""
+    from app.scanner import orchestrate_scan
+
+    monkeypatch.setenv("SCAN_SUBNET", "10.0.0.0/24")
+    with patch("app.scanner.run_arp_scan", return_value=[]):
+        result = orchestrate_scan(subnet="10.0.0.0/24")
+    assert result.hosts == []

--- a/frontend/src/constants/severity.ts
+++ b/frontend/src/constants/severity.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared severity constants — single source of truth for ordering,
+ * colours, and label lists used across pages and components.
+ */
+import type { Severity } from "../types/api";
+
+/** Ordered from most to least severe. */
+export const SEV_LEVELS: Severity[] = ["critical", "high", "medium", "low"];
+
+/** Map severity → CSS colour variable. */
+export const SEV_COLORS: Record<Severity, string> = {
+  critical: "var(--color-accent-danger)",
+  high: "var(--color-accent-warning)",
+  medium: "var(--color-accent-caution)",
+  low: "var(--color-accent-positive)",
+} as const;
+
+/** Map severity → sort rank (lower = more severe). */
+export const SEV_RANK: Record<Severity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+} as const;

--- a/frontend/src/pages/DeviceDetailPage.tsx
+++ b/frontend/src/pages/DeviceDetailPage.tsx
@@ -5,10 +5,11 @@
 import { memo, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Card, Badge, SkeletonCard, PageHeader } from "../components";
+import { SEV_LEVELS } from "../constants/severity";
 import { useDevice, useRisks, useDeviceRecommendations } from "../hooks";
 import type { Risk, Recommendation, Severity } from "../types/api";
 
-const SEV_ORDER: Severity[] = ["critical", "high", "medium", "low"];
+const SEV_ORDER: Severity[] = SEV_LEVELS;
 
 const RiskCard = memo(function RiskCard({ risk }: { risk: Risk }) {
   return (
@@ -81,6 +82,7 @@ export function DeviceDetailPage() {
   const { recommendations, loading: recsLoading } =
     useDeviceRecommendations(deviceId);
   const [togglingTrust, setTogglingTrust] = useState(false);
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
 
   // Build a map of risk_id → recommendation for O(1) lookup
   const recByRiskId = useMemo(() => {
@@ -119,12 +121,29 @@ export function DeviceDetailPage() {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
       })
       .then(() => refetch())
-      .catch(() => {})
+      .catch(() => {
+        setToastMsg("Failed to update trusted status. Please try again.");
+      })
       .finally(() => setTogglingTrust(false));
   };
 
   return (
     <div>
+      {toastMsg && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-[var(--color-accent-danger)]/40 bg-[var(--color-accent-danger)]/10 px-4 py-2.5 text-sm text-[var(--color-accent-danger)]"
+        >
+          {toastMsg}
+          <button
+            onClick={() => setToastMsg(null)}
+            className="ml-3 font-bold opacity-70 hover:opacity-100"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <div className="mb-1 flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
         <Link
           to="/devices"

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -4,16 +4,9 @@
  */
 import { useMemo } from "react";
 import { Card, PageHeader, SkeletonCard } from "../components";
+import { SEV_COLORS, SEV_LEVELS } from "../constants/severity";
 import { useScans } from "../hooks";
 import type { Scan } from "../types/api";
-
-// ── Colour palette ────────────────────────────────────────────────────────────
-const SEV_COLORS = {
-  critical: "var(--color-accent-danger)",
-  high: "var(--color-accent-warning)",
-  medium: "var(--color-accent-caution)",
-  low: "var(--color-accent-positive)",
-} as const;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -85,9 +78,6 @@ function BarChart({
 
 // ── Stacked bar chart (risk severity trend) ───────────────────────────────────
 
-type SevKey = "critical" | "high" | "medium" | "low";
-const SEV_KEYS: SevKey[] = ["critical", "high", "medium", "low"];
-
 interface StackedBarChartProps {
   data: {
     label: string;
@@ -119,7 +109,7 @@ function StackedBarChart({ data, height = 120 }: StackedBarChartProps) {
           let yOffset = height;
           return (
             <g key={i}>
-              {SEV_KEYS.map((sev) => {
+              {SEV_LEVELS.map((sev) => {
                 const val = d[sev];
                 const segH = Math.round((val / max) * height);
                 yOffset -= segH;
@@ -160,7 +150,7 @@ function StackedBarChart({ data, height = 120 }: StackedBarChartProps) {
 function SevLegend() {
   return (
     <div className="mt-2 flex flex-wrap gap-3">
-      {SEV_KEYS.map((sev) => (
+      {SEV_LEVELS.map((sev) => (
         <span
           key={sev}
           className="flex items-center gap-1 text-xs text-[var(--color-text-secondary)]"

--- a/frontend/src/pages/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage.tsx
@@ -5,17 +5,12 @@
 import { memo, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Card, Badge, SkeletonCard, PageHeader } from "../components";
+import { SEV_RANK } from "../constants/severity";
 import { useRecommendations } from "../hooks";
-import type { Recommendation, Severity } from "../types/api";
+import type { Recommendation } from "../types/api";
 
 type SortKey = "severity" | "effort" | "impact";
 
-const SEV_ORDER: Record<Severity, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-};
 const EFFORT_ORDER: Record<string, number> = { low: 0, medium: 1, high: 2 };
 const IMPACT_ORDER: Record<string, number> = {
   critical: 0,
@@ -58,7 +53,7 @@ export function RecommendationsPage() {
     return [...recommendations].sort((a, b) => {
       switch (sortKey) {
         case "severity":
-          return (SEV_ORDER[a.severity] ?? 99) - (SEV_ORDER[b.severity] ?? 99);
+          return (SEV_RANK[a.severity] ?? 99) - (SEV_RANK[b.severity] ?? 99);
         case "effort":
           return (
             (EFFORT_ORDER[a.effort] ?? 99) - (EFFORT_ORDER[b.effort] ?? 99)

--- a/frontend/src/pages/RisksPage.tsx
+++ b/frontend/src/pages/RisksPage.tsx
@@ -5,19 +5,11 @@
 import React, { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Card, Badge, SkeletonCard, PageHeader } from "../components";
+import { SEV_COLORS, SEV_LEVELS } from "../constants/severity";
 import { useRisks, useRiskSummary, useDevices } from "../hooks";
 import type { Risk, Severity } from "../types/api";
 
-const SEVERITIES: Severity[] = ["critical", "high", "medium", "low"];
-
-const SEV_LEVELS: Severity[] = ["critical", "high", "medium", "low"];
-
-const SEV_COLOR: Record<Severity, string> = {
-  critical: "var(--color-accent-danger)",
-  high: "var(--color-accent-warning)",
-  medium: "var(--color-accent-caution)",
-  low: "var(--color-accent-positive)",
-};
+const SEVERITIES: Severity[] = SEV_LEVELS;
 
 // Modal for full risk detail
 function RiskModal({ risk, onClose }: { risk: Risk; onClose: () => void }) {
@@ -114,7 +106,7 @@ export function RisksPage() {
           totalRisks > 0
             ? Math.round(((summary?.[sev] ?? 0) / totalRisks) * 100)
             : 0,
-        color: SEV_COLOR[sev],
+        color: SEV_COLORS[sev],
       })),
     [summary, totalRisks],
   );


### PR DESCRIPTION
Closes #63, #64, #66, #69, #70

## Changes
- **#63**: Wrap `ET.fromstring` in try/except → `RuntimeError` on malformed nmap XML
- **#64**: Validate CIDR with `ipaddress.ip_network()` before scan starts; returns error warning on invalid input
- **#66**: Delete stale ports after rescan in `_persist_result()` — ports removed between scans are now cleaned up
- **#69**: Error toast on trust toggle failure in DeviceDetailPage
- **#70**: Extract `SEV_LEVELS`, `SEV_COLORS`, `SEV_RANK` to `constants/severity.ts`; HistoryPage, RisksPage, RecommendationsPage, DeviceDetailPage all use shared constants