### PR TITLE
fix: container startup failure — db directory permissions

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sqlalchemy import create_engine, text
@@ -43,6 +44,14 @@ def _migrate_schema(engine) -> None:
 
 def init_db() -> None:
     """Create all tables if they don't exist."""
+    # Ensure the data directory exists — required when a volume is freshly mounted
+    # and the directory hasn't been initialised yet (e.g. first run with a bind mount).
+    _db_url = DATABASE_URL
+    if _db_url.startswith("sqlite:///") and not _db_url.startswith("sqlite:///:"):
+        # Strip the scheme prefix; four slashes = absolute path, three = relative
+        db_path = Path(_db_url[len("sqlite:///") :])
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
     from app.models import device as _device  # noqa: F401 — side-effect import registers ORM tables
     from app.models import (
         recommendation as _recommendation,  # noqa: F401 — side-effect import registers ORM tables

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,10 +74,6 @@ COPY --from=frontend-build /build/dist ./frontend/dist
 # Persist the SQLite database in a dedicated data directory
 RUN mkdir -p /app/data && chown -R crawler:crawler /app
 
-# Declare the data directory as a volume so Docker persists it even without
-# an explicit -v flag.  docker-compose and Unraid override with named/host mounts.
-VOLUME /app/data
-
 # Drop to non-root
 USER crawler
 


### PR DESCRIPTION
## Problem
The `VOLUME /app/data` instruction added in the previous PR caused Docker to mount an anonymous (or bind) volume over `/app/data`, **discarding the `chown crawler:crawler` from the build step** and leaving the directory owned by root. The `crawler` user (uid 1000) could not create the SQLite file, resulting in:
```
sqlite3.OperationalError: unable to open database file
ERROR: Application startup failed. Exiting.
```

## Fix
- **Remove `VOLUME /app/data`** — explicit named volumes (docker-compose) and bind mounts (Unraid) already provide persistence; the declaration was redundant and caused the permission issue.
- **Add `Path(db_path).parent.mkdir(parents=True, exist_ok=True)` in `init_db()`** — ensures the data directory is created on first run even if the volume was mounted empty (fresh bind mount or new named volume). Safe no-op if it already exists.