### PR TITLE
feat: device type classification and IoT hygiene flags (#91)

### DIFF
--- a/backend/app/analysis/checks.py
+++ b/backend/app/analysis/checks.py
@@ -608,6 +608,57 @@ def check_wireguard_vpn(device: Device) -> list[RiskData]:
     ]
 
 
+# ── IoT-specific checks ───────────────────────────────────────────────────────
+
+
+def check_iot_admin_panel_http(device: Device) -> list[RiskData]:
+    """MEDIUM — IoT device with plain HTTP admin panel (port 80/8080)."""
+    if getattr(device, "device_type", None) != "iot":
+        return []
+    http_ports = _has_port(device, 80, 8080)
+    if not http_ports:
+        return []
+    port_list = ", ".join(str(p.port_number) for p in http_ports)
+    return [
+        RiskData(
+            check_id="iot_admin_panel_http",
+            severity="medium",
+            title="IoT device admin panel accessible over plain HTTP",
+            description=(
+                f"IoT device {device.ip_address} exposes an admin panel on port "
+                f"{port_list} over unencrypted HTTP. "
+                "Credentials and device configuration are transmitted in plain text, "
+                "making them easy to intercept on a shared Wi-Fi network."
+            ),
+        )
+    ]
+
+
+def check_iot_remote_shell(device: Device) -> list[RiskData]:
+    """HIGH — IoT device with Telnet or SSH open (unexpected for consumer IoT)."""
+    if getattr(device, "device_type", None) != "iot":
+        return []
+    shell_ports = _has_port(device, 22, 23)
+    if not shell_ports:
+        return []
+    port_names = {22: "SSH", 23: "Telnet"}
+    services = ", ".join(port_names.get(p.port_number, str(p.port_number)) for p in shell_ports)
+    return [
+        RiskData(
+            check_id="iot_remote_shell",
+            severity="high",
+            title="IoT device exposes a remote shell",
+            description=(
+                f"IoT device {device.ip_address} has {services} open. "
+                "Consumer IoT devices rarely require remote shell access and its presence "
+                "may indicate firmware backdoors, manufacturer debug ports, or a "
+                "compromised device. Investigate whether this service is intentional "
+                "and disable it if not required."
+            ),
+        )
+    ]
+
+
 # ── Compound / pattern-based checks ──────────────────────────────────────────
 
 
@@ -755,6 +806,9 @@ ALL_CHECKS = [
     check_home_assistant_exposed,
     check_tftp_open,
     check_wireguard_vpn,
+    # IoT-specific checks
+    check_iot_admin_panel_http,
+    check_iot_remote_shell,
     # Compound / pattern checks
     check_multiple_admin_panels,
     check_database_and_web_exposed,

--- a/backend/app/analysis/device_classifier.py
+++ b/backend/app/analysis/device_classifier.py
@@ -1,0 +1,178 @@
+"""Device type classifier — infers device category from vendor/hostname/OS heuristics.
+
+Returns one of: 'iot' | 'server' | 'router' | 'workstation' | 'unknown'
+"""
+
+from __future__ import annotations
+
+# Vendor substring → device type (checked in order: router > server > IoT > workstation)
+_ROUTER_VENDORS = (
+    "mikrotik",
+    "ubiquiti",
+    "ubnt",
+    "avm",
+    "netgear",
+    "asus",
+    "linksys",
+    "cisco",
+    "juniper",
+    "aruba",
+    "zyxel",
+    "draytek",
+    "gl.inet",
+    "gl inet",
+    "openwrt",
+)
+_SERVER_VENDORS = (
+    "qnap",
+    "synology",
+    "truenas",
+    "dell",
+    "hewlett packard",
+    "hp ",  # prefix space to avoid matching "php"
+    "supermicro",
+    "western digital",
+    "wd ",
+    "seagate",
+    "thecus",
+    "buffalo",
+    "asustor",
+)
+_IOT_VENDORS = (
+    "raspberry pi",
+    "espressif",
+    "philips",
+    "xiaomi",
+    "nest",
+    "tp-link",
+    "tplink",
+    "tuya",
+    "shelly",
+    "sonos",
+    "roku",
+    "amazon",
+    "google",
+    "belkin",
+    "wemo",
+    "ring",
+    "arlo",
+    "wyze",
+    "eufy",
+    "anker",
+    "lifx",
+    "yeelight",
+    "meross",
+    "sengled",
+    "ikea",
+    "sonoff",
+    "ewelink",
+    "tasmota",
+    "particle",
+    "arduino",
+    "nordic semi",
+)
+_WORKSTATION_VENDORS = (
+    "apple",
+    "microsoft",
+    "intel",
+    "lenovo",
+    "samsung",
+    "lg electron",
+    "acer",
+    "asus",
+)
+
+# Hostname substring → device type
+_ROUTER_HOSTNAMES = (
+    "router",
+    "gateway",
+    "mikrotik",
+    "ubnt",
+    "unifi",
+    "openwrt",
+    "pfsense",
+    "opnsense",
+    "fritzbox",
+    "fritz",
+    "draytek",
+)
+_SERVER_HOSTNAMES = (
+    "nas",
+    "plex",
+    "jellyfin",
+    "truenas",
+    "synology",
+    "qnap",
+    "proxmox",
+    "homeassistant",
+    "home-assistant",
+    "pihole",
+    "pi-hole",
+    "adguard",
+    "dockerhost",
+    "unraid",
+)
+_IOT_HOSTNAMES = (
+    "esp",
+    "sonoff",
+    "shelly",
+    "tasmota",
+    "homebridge",
+    "philips-hue",
+    "hue",
+    "roku",
+    "echo",
+    "alexa",
+    "google-home",
+    "chromecast",
+    "nest",
+    "arlo",
+    "wyze",
+    "ring",
+    "lifx",
+    "yeelight",
+    "meross",
+    "sonos",
+    "tplink",
+    "tp-link",
+)
+
+
+def classify_device_type(
+    vendor: str | None,
+    hostname: str | None,
+    os_guess: str | None,
+) -> str:
+    """Return the device type inferred from vendor, hostname, and OS.
+
+    Priority order: router > server > iot > workstation > unknown
+    """
+    vendor_l = (vendor or "").lower()
+    hostname_l = (hostname or "").lower()
+    os_l = (os_guess or "").lower()
+
+    # ── Router ────────────────────────────────────────────────────────────────
+    if any(v in vendor_l for v in _ROUTER_VENDORS):
+        return "router"
+    if any(h in hostname_l for h in _ROUTER_HOSTNAMES):
+        return "router"
+
+    # ── Server ────────────────────────────────────────────────────────────────
+    if any(v in vendor_l for v in _SERVER_VENDORS):
+        return "server"
+    if any(h in hostname_l for h in _SERVER_HOSTNAMES):
+        return "server"
+
+    # ── IoT ───────────────────────────────────────────────────────────────────
+    if any(v in vendor_l for v in _IOT_VENDORS):
+        return "iot"
+    if any(h in hostname_l for h in _IOT_HOSTNAMES):
+        return "iot"
+
+    # ── Workstation ───────────────────────────────────────────────────────────
+    if any(v in vendor_l for v in _WORKSTATION_VENDORS):
+        return "workstation"
+    if "windows" in os_l or "macos" in os_l or "mac os" in os_l:
+        return "workstation"
+
+    return "unknown"

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -35,6 +35,7 @@ class DeviceOut(BaseModel):
     os_guess: str | None
     label: str | None
     trusted: bool
+    device_type: str | None  # iot | server | router | workstation | unknown
     first_seen: str | None  # ISO-8601 string
     last_seen: str | None
     ports: list[PortOut] = []
@@ -173,6 +174,7 @@ def _device_to_out(d) -> DeviceOut:  # noqa: ANN001 — SQLAlchemy instance, val
         os_guess=d.os_guess,
         label=d.label,
         trusted=bool(d.trusted),
+        device_type=d.device_type,
         first_seen=d.first_seen.isoformat() if d.first_seen else None,
         last_seen=d.last_seen.isoformat() if d.last_seen else None,
         security_score=_device_security_score(d),

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -37,6 +37,7 @@ def _migrate_schema(engine) -> None:
         ("devices", "label", "TEXT"),
         ("recommendations", "attack_scenario", "TEXT"),
         ("recommendations", "likelihood", "TEXT"),
+        ("devices", "device_type", "TEXT DEFAULT 'unknown'"),
     ]
     with engine.connect() as conn:
         for table, column, col_def in migrations:

--- a/backend/app/models/device.py
+++ b/backend/app/models/device.py
@@ -31,6 +31,7 @@ class Device(Base):
     hostname = Column(String, nullable=True)
     os_guess = Column(String, nullable=True)
     label = Column(String, nullable=True)  # user-assigned friendly name
+    device_type = Column(String, nullable=True, default="unknown")  # iot|server|router|workstation
     trusted = Column(Boolean, nullable=False, default=False, server_default="0")
     first_seen = Column(DateTime, default=func.now())
     last_seen = Column(DateTime, default=func.now(), onupdate=func.now())

--- a/backend/app/recommendations/__init__.py
+++ b/backend/app/recommendations/__init__.py
@@ -727,6 +727,59 @@ _CATALOGUE: dict[str, _Advice] = {
             "Its co-existence with SSH suggests it was never intentionally kept."
         ),
     ),
+    "iot_admin_panel_http": _Advice(
+        title="Enable HTTPS on the IoT device admin panel",
+        description=(
+            "This IoT device exposes its admin interface over plain HTTP. "
+            "Credentials and settings can be intercepted by anyone on the same network."
+        ),
+        steps=[
+            "Access the IoT device's admin panel in your browser.",
+            "Check the Settings or Network section for HTTPS or TLS options.",
+            "If HTTPS is available, enable it and disable plain HTTP.",
+            "If HTTPS is not available, check for a firmware update that adds TLS support.",
+            "As a mitigation, apply a firewall rule limiting access to the admin port "
+            "to trusted management hosts only.",
+        ],
+        effort="low",
+        impact="medium",
+        attack_scenario=(
+            "An attacker on your Wi-Fi intercepts the HTTP session to your IoT device "
+            "and captures your login credentials or session cookie. They then change "
+            "device settings, disable firmware updates, or use the device as a pivot "
+            "point into the rest of the network."
+        ),
+        likelihood=(
+            "Medium — many consumer IoT devices ship with HTTP-only management interfaces. "
+            "The risk is amplified on networks where IoT devices share Wi-Fi with workstations."
+        ),
+    ),
+    "iot_remote_shell": _Advice(
+        title="Disable the remote shell on this IoT device",
+        description=(
+            "Consumer IoT devices should not expose SSH or Telnet. "
+            "Its presence may indicate a debug port, backdoor, or compromised firmware."
+        ),
+        steps=[
+            "Identify the shell service (SSH port 22 or Telnet port 23).",
+            "Access the device's admin UI and disable remote shell access if the option exists.",
+            "Check the manufacturer's support pages for a firmware update or security advisory.",
+            "If the service cannot be disabled, apply a firewall rule to block the port.",
+            "Consider whether the device should be replaced if no fix is available.",
+        ],
+        effort="medium",
+        impact="high",
+        attack_scenario=(
+            "Many consumer IoT devices ship with hard-coded credentials for debug SSH or "
+            "Telnet access. An attacker connects using published default credentials, gains "
+            "root access to the device, and uses it as a persistent foothold in your network."
+        ),
+        likelihood=(
+            "Medium — especially for older or budget IoT devices. Hard-coded credentials "
+            "for SSH/Telnet on IoT firmware are a known vulnerability class with "
+            "published exploit databases."
+        ),
+    ),
 }
 
 

--- a/backend/app/scan_runner.py
+++ b/backend/app/scan_runner.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
+from app.analysis.device_classifier import classify_device_type
 from app.db import SessionLocal, upsert_device, upsert_port
 from app.scanner import ScanResult, orchestrate_scan
 
@@ -175,6 +176,11 @@ def _persist_result(db: Session, result: ScanResult) -> _PersistSummary:
             hostname=nh.hostname or None,
             os_guess=nh.os_guess or None,
         )
+        device.device_type = classify_device_type(
+            vendor=device.vendor,
+            hostname=nh.hostname or None,
+            os_guess=nh.os_guess or None,
+        )
         db.flush()
         if nh.ip not in existing_ips:
             summary.new_device_ids.append(device.id)
@@ -232,6 +238,11 @@ def _persist_result(db: Session, result: ScanResult) -> _PersistSummary:
             ip_address=ah.ip,
             mac_address=ah.mac or None,
             vendor=ah.vendor or None,
+        )
+        device.device_type = classify_device_type(
+            vendor=ah.vendor or None,
+            hostname=device.hostname,
+            os_guess=device.os_guess,
         )
         db.flush()
         if ah.ip not in existing_ips:

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -858,3 +858,126 @@ def test_trusted_device_generates_no_risks(db_session):
         db_session.execute(sa_select(Risk).where(Risk.device_id == device.id)).scalars().all()
     )
     assert remaining == []
+
+
+# ── device_classifier ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_classifier_iot_vendor():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type("Espressif Inc.", None, None) == "iot"
+
+
+@pytest.mark.unit
+def test_classifier_iot_hostname():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type(None, "shelly-relay-1", None) == "iot"
+
+
+@pytest.mark.unit
+def test_classifier_server_vendor():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type("QNAP Systems", None, None) == "server"
+
+
+@pytest.mark.unit
+def test_classifier_server_hostname():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type(None, "proxmox-node1", None) == "server"
+
+
+@pytest.mark.unit
+def test_classifier_router_vendor():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type("MikroTik", None, None) == "router"
+
+
+@pytest.mark.unit
+def test_classifier_workstation_os():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type(None, None, "Windows 10") == "workstation"
+
+
+@pytest.mark.unit
+def test_classifier_unknown():
+    from app.analysis.device_classifier import classify_device_type
+
+    assert classify_device_type(None, None, None) == "unknown"
+
+
+# ── check_iot_admin_panel_http ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_iot_admin_http_fires_for_iot_on_port_80():
+    from app.analysis.checks import check_iot_admin_panel_http
+
+    device = _make_device(ports=[_make_port(80)])
+    device.device_type = "iot"
+    results = check_iot_admin_panel_http(device)
+    assert len(results) == 1
+    assert results[0].check_id == "iot_admin_panel_http"
+    assert results[0].severity == "medium"
+
+
+@pytest.mark.unit
+def test_iot_admin_http_skips_non_iot():
+    from app.analysis.checks import check_iot_admin_panel_http
+
+    device = _make_device(ports=[_make_port(80)])
+    device.device_type = "server"
+    results = check_iot_admin_panel_http(device)
+    assert results == []
+
+
+@pytest.mark.unit
+def test_iot_admin_http_skips_no_http():
+    from app.analysis.checks import check_iot_admin_panel_http
+
+    device = _make_device(ports=[_make_port(443)])
+    device.device_type = "iot"
+    results = check_iot_admin_panel_http(device)
+    assert results == []
+
+
+# ── check_iot_remote_shell ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_iot_remote_shell_fires_for_iot_ssh():
+    from app.analysis.checks import check_iot_remote_shell
+
+    device = _make_device(ports=[_make_port(22)])
+    device.device_type = "iot"
+    results = check_iot_remote_shell(device)
+    assert len(results) == 1
+    assert results[0].check_id == "iot_remote_shell"
+    assert results[0].severity == "high"
+
+
+@pytest.mark.unit
+def test_iot_remote_shell_fires_for_iot_telnet():
+    from app.analysis.checks import check_iot_remote_shell
+
+    device = _make_device(ports=[_make_port(23)])
+    device.device_type = "iot"
+    results = check_iot_remote_shell(device)
+    assert len(results) == 1
+    assert results[0].check_id == "iot_remote_shell"
+
+
+@pytest.mark.unit
+def test_iot_remote_shell_skips_non_iot():
+    from app.analysis.checks import check_iot_remote_shell
+
+    device = _make_device(ports=[_make_port(22)])
+    device.device_type = "server"
+    results = check_iot_remote_shell(device)
+    assert results == []

--- a/frontend/src/components/DeviceTypeBadge.tsx
+++ b/frontend/src/components/DeviceTypeBadge.tsx
@@ -1,0 +1,58 @@
+/** DeviceTypeBadge — small coloured pill showing device type with an icon. */
+
+const TYPE_CONFIG: Record<
+  string,
+  { icon: string; label: string; className: string }
+> = {
+  iot: {
+    icon: "📡",
+    label: "IoT",
+    className:
+      "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+  },
+  server: {
+    icon: "🖥",
+    label: "Server",
+    className:
+      "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  },
+  router: {
+    icon: "🔀",
+    label: "Router",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  },
+  workstation: {
+    icon: "💻",
+    label: "Workstation",
+    className:
+      "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  },
+  unknown: {
+    icon: "❓",
+    label: "Unknown",
+    className:
+      "bg-[var(--color-surface)] text-[var(--color-text-secondary)] border border-[var(--color-border)]",
+  },
+};
+
+export function DeviceTypeBadge({
+  type,
+  size = "sm",
+}: {
+  type: string | null | undefined;
+  size?: "sm" | "md";
+}) {
+  const cfg = TYPE_CONFIG[type ?? "unknown"] ?? TYPE_CONFIG["unknown"];
+  const sizeClass =
+    size === "sm" ? "px-1.5 py-0.5 text-xs" : "px-2 py-1 text-sm";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded font-medium ${sizeClass} ${cfg.className}`}
+      title={`Device type: ${cfg.label}`}
+    >
+      <span aria-hidden="true">{cfg.icon}</span>
+      {cfg.label}
+    </span>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -25,3 +25,5 @@ export type { ScanBannerProps } from "./ScanBanner";
 export { PageHeader } from "./PageHeader";
 
 export { ScoreBadge } from "./ScoreBadge";
+
+export { DeviceTypeBadge } from "./DeviceTypeBadge";

--- a/frontend/src/pages/DeviceDetailPage.tsx
+++ b/frontend/src/pages/DeviceDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   SkeletonCard,
   PageHeader,
   ScoreBadge,
+  DeviceTypeBadge,
 } from "../components";
 import { SEV_LEVELS } from "../constants/severity";
 import { useDevice, useRisks, useDeviceRecommendations } from "../hooks";
@@ -298,6 +299,14 @@ export function DeviceDetailPage() {
               </dd>
             </div>
           ))}
+          <div className="flex flex-col">
+            <dt className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+              Device Type
+            </dt>
+            <dd className="mt-1">
+              <DeviceTypeBadge type={device.device_type} size="md" />
+            </dd>
+          </div>
           <div className="flex flex-col">
             <dt className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
               Security Score

--- a/frontend/src/pages/DevicesPage.tsx
+++ b/frontend/src/pages/DevicesPage.tsx
@@ -10,9 +10,10 @@ import {
   SkeletonTable,
   PageHeader,
   ScoreBadge,
+  DeviceTypeBadge,
 } from "../components";
 import { useDevices, useRisks } from "../hooks";
-import type { Device } from "../types/api";
+import type { Device, DeviceType } from "../types/api";
 
 /** Inline label editor that saves on blur or Enter, cancels on Escape. */
 function LabelCell({
@@ -167,6 +168,7 @@ export function DevicesPage() {
   const { risks } = useRisks();
   const [filter, setFilter] = useState("");
   const [osFilter, setOsFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState<DeviceType | "">("");
   const [sortKey, setSortKey] = useState<SortKey>("ip_address");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -194,9 +196,10 @@ export function DevicesPage() {
           (d.hostname ?? "").toLowerCase().includes(q) ||
           (d.mac_address ?? "").toLowerCase().includes(q) ||
           (d.os_guess ?? "").toLowerCase().includes(q)) &&
-        (osFilter === "" || d.os_guess === osFilter),
+        (osFilter === "" || d.os_guess === osFilter) &&
+        (typeFilter === "" || d.device_type === typeFilter),
     );
-  }, [devices, filter, osFilter]);
+  }, [devices, filter, osFilter, typeFilter]);
 
   const sorted = useMemo(
     () => sortDevices(filtered, riskCounts, sortKey, sortDir),
@@ -249,6 +252,19 @@ export function DevicesPage() {
                 ))}
               </select>
             )}
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value as DeviceType | "")}
+              aria-label="Filter by device type"
+              className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)]"
+            >
+              <option value="">All Types</option>
+              <option value="iot">IoT</option>
+              <option value="server">Server</option>
+              <option value="router">Router</option>
+              <option value="workstation">Workstation</option>
+              <option value="unknown">Unknown</option>
+            </select>
           </div>
         }
       />
@@ -300,13 +316,16 @@ export function DevicesPage() {
                       <SortIcon k={key} />
                     </th>
                   ))}
+                  <th scope="col" className="px-4 py-3">
+                    Type
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {sorted.length === 0 && (
                   <tr>
                     <td
-                      colSpan={6}
+                      colSpan={8}
                       className="px-4 py-8 text-center text-[var(--color-text-secondary)]"
                     >
                       No devices match the filter.
@@ -364,6 +383,9 @@ export function DevicesPage() {
                       {device.last_seen
                         ? new Date(device.last_seen).toLocaleString()
                         : "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <DeviceTypeBadge type={device.device_type} />
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -11,6 +11,13 @@ export interface Port {
   version_banner: string | null;
 }
 
+export type DeviceType =
+  | "iot"
+  | "server"
+  | "router"
+  | "workstation"
+  | "unknown";
+
 export interface Device {
   id: number;
   ip_address: string;
@@ -20,6 +27,7 @@ export interface Device {
   os_guess: string | null;
   label: string | null;
   trusted: boolean;
+  device_type: DeviceType | null;
   first_seen: string | null; // ISO-8601
   last_seen: string | null;
   ports: Port[];


### PR DESCRIPTION
## Summary

Implements issue #91 — classifies discovered devices and adds IoT-specific hygiene checks.

### Changes

**Backend:**
- Added `device_type` column to `Device` model + DB migration
- New `device_classifier.py` with vendor/hostname/OS heuristics (router → server → IoT → workstation → unknown priority)
- `scan_runner.py`: calls classifier after every `upsert_device()` for both nmap and ARP-only hosts
- `check_iot_admin_panel_http`: fires when an IoT device has port 80/8080 over plain HTTP (medium)
- `check_iot_remote_shell`: fires when an IoT device has SSH (22) or Telnet (23) open (high)
- Both checks respect `device_type` — only fire for devices classified as IoT
- 2 new catalogue entries with attack_scenario + likelihood
- `DeviceOut` schema exposes `device_type`

**Frontend:**
- `DeviceTypeBadge` component: colour-coded pill (purple=IoT, blue=server, green=router, amber=workstation)
- `DevicesPage`: Type column + filter dropdown
- `DeviceDetailPage`: Device Type row in metadata section
- `DeviceType` TypeScript type exported from `types/api.ts`

### Testing
- 13 new unit tests (254 total): 7 classifier, 3 admin_http check, 3 remote_shell check
- All 254 tests pass

Closes #91