### PR TITLE
fix: shorten APP_VERSION to 7-char git short SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,11 @@ jobs:
             org.opencontainers.image.vendor=talesofthemoon
             org.opencontainers.image.licenses=MIT
 
+      # ── Short SHA for version label ───────────────────────────────────────────
+      - name: Set short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       # ── Build and push per-arch digest ────────────────────────────────────────
       #   On PRs: build only (no push, no digest needed).
       #   On push/tag: push digest-only (no manifest tag) via outputs; the merge
@@ -97,7 +102,7 @@ jobs:
           # On PRs: type=docker (local load, no push). On push/tag: digest-only push.
           outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || 'type=docker' }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: APP_VERSION=sha-${{ github.sha }}
+          build-args: APP_VERSION=${{ steps.sha.outputs.short }}
           # Per-arch GHA cache (keyed by platform so they don't collide)
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
@@ -136,6 +141,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       # Build the image locally for scanning (amd64 only — same OS layers as arm64)
       - name: Build image for scanning
         uses: docker/build-push-action@v6
@@ -145,7 +154,7 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: networkcrawler:scan
-          build-args: APP_VERSION=sha-${{ github.sha }}
+          build-args: APP_VERSION=${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=linux/amd64
 
       # Run Trivy — report CRITICAL/HIGH; results visible in Security tab without blocking merges


### PR DESCRIPTION
## Problem
`APP_VERSION` was set to `sha-<full 40-char SHA>` — a 44-character string that overlaps UI elements.

## Fix
Replace with the standard 7-character git short SHA (e.g. `abc1234`).

### How
Added a `Set short SHA` step before each `build-push-action` call:
```bash
echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
```
Both the matrix build job and the Trivy scan job updated.

**Before:** `sha-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2`  
**After:** `a1b2c3d`

Closes #108