### PR TITLE
fix: topology graph empty after async fetch

### DIFF
--- a/frontend/src/pages/TopologyPage.tsx
+++ b/frontend/src/pages/TopologyPage.tsx
@@ -210,16 +210,19 @@ export function TopologyPage() {
     [topology, gateway],
   );
 
-  const [rfNodes, , onNodesChange] = useNodesState(initialNodes);
-  const [rfEdges, , onEdgesChange] = useEdgesState(initialEdges);
+  const [rfNodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [rfEdges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  // Sync when topology loads
-  const [synced, setSynced] = useState(false);
+  // Sync React Flow state when topology data arrives (useNodesState/useEdgesState
+  // only consume their argument as an initial value, so async fetch results must
+  // be pushed in explicitly via setNodes/setEdges).
   useEffect(() => {
-    if (topology.length > 0 && !synced) {
-      setSynced(true);
-    }
-  }, [topology, synced]);
+    setNodes(initialNodes);
+  }, [initialNodes, setNodes]);
+
+  useEffect(() => {
+    setEdges(initialEdges);
+  }, [initialEdges, setEdges]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Root cause
`useNodesState(initialNodes)` and `useEdgesState(initialEdges)` from `@xyflow/react` only use their argument as the **initial** value at mount. The topology data is fetched asynchronously in a `useEffect`, so when React Flow initialised, both arrays were empty — and never updated when the fetch resolved.

There was an existing `synced` workaround (lines 216–222) that set a boolean flag but never called `setNodes` or `setEdges`, making it completely inert.

## Fix
Capture `setNodes` and `setEdges` from the hooks and push updates via `useEffect` whenever `initialNodes`/`initialEdges` change:

```ts
const [rfNodes, setNodes, onNodesChange] = useNodesState(initialNodes);
const [rfEdges, setEdges, onEdgesChange] = useEdgesState(initialEdges);

useEffect(() => { setNodes(initialNodes); }, [initialNodes, setNodes]);
useEffect(() => { setEdges(initialEdges); }, [initialEdges, setEdges]);
```

Removes the dead `synced` state.

## Testing
- 146 frontend tests pass
- ESLint + Prettier clean

Closes #109